### PR TITLE
修正跨进程调用结果转化异常引起的调用方ANR问题

### DIFF
--- a/cc/src/main/java/com/billy/cc/core/component/RemoteCCService.java
+++ b/cc/src/main/java/com/billy/cc/core/component/RemoteCCService.java
@@ -88,9 +88,15 @@ public class RemoteCCService extends IRemoteCCService.Stub {
 
     private static void doCallback(IRemoteCallback callback, String callId, CCResult ccResult) {
         try {
-            RemoteCCResult remoteCCResult = new RemoteCCResult(ccResult);
-            if (CC.VERBOSE_LOG) {
-                CC.verboseLog(callId, "callback to other process. RemoteCCResult: %s", remoteCCResult.toString());
+            RemoteCCResult remoteCCResult;
+            try{
+                remoteCCResult = new RemoteCCResult(ccResult);
+                if (CC.VERBOSE_LOG) {
+                    CC.verboseLog(callId, "callback to other process. RemoteCCResult: %s", remoteCCResult.toString());
+                }
+            }catch(Exception e){
+                remoteCCResult = new RemoteCCResult(CCResult.error("result can not be transformed for IPC"));
+                CC.verboseLog(callId, "remote CC successed. But result can not be converted for IPC. RemoteCCResult: %s", remoteCCResult.toString());
             }
             callback.callback(remoteCCResult);
         } catch (RemoteException e) {


### PR DESCRIPTION
当一个跨进程调用的结果不能被RemoteParamUtil.toRemoteMap方法正常转化时，被调用的进程crash导致此次调用的RemoteCCResult不能被正确发送，此时调用的进程一直处于wait4Result阶段，出现ANR。我的pull request修正了这个问题。