### PR TITLE
CC升级到2.1.5，cc-register插件升级到1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ CC的设计灵感来源于服务端的服务化架构，将组件之间的关系
 
 ## 创建组件
 
-创建一个组件也十分简单：只要创建一个`IComponent`接口的实现类，在onCall方法中实现组件暴露的服务即可
+创建一个组件很简单：只要创建一个`IComponent`接口的实现类，在onCall方法中实现组件暴露的服务即可
 
 ```java
 public class ComponentA implements IComponent {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
     supportVersion = '25.3.1'
 
     deps = [
-        cc       : 'com.billy.android:cc:2.1.2'
+        cc       : 'com.billy.android:cc:2.1.4'
 //        cc       : project(':cc')
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
     supportVersion = '25.3.1'
 
     deps = [
-        cc       : 'com.billy.android:cc:2.1.4'
+        cc       : 'com.billy.android:cc:2.1.5'
 //        cc       : project(':cc')
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.billy.android:cc-register:1.0.8'
+        classpath 'com.billy.android:cc-register:1.0.9'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/cc-register/build.gradle
+++ b/cc-register/build.gradle
@@ -26,7 +26,7 @@ ext {
     siteUrl = 'https://github.com/luckybilly/CC'
     gitUrl = 'https://github.com/luckybilly/CC.git'
 
-    libraryVersion = '1.0.8'
+    libraryVersion = '1.0.9'
 
     developerId = 'billy'
     developerName = 'billy'

--- a/cc-register/src/main/groovy/com/billy/android/register/cc/generator/ManifestGenerator.groovy
+++ b/cc-register/src/main/groovy/com/billy/android/register/cc/generator/ManifestGenerator.groovy
@@ -27,7 +27,7 @@ class ManifestGenerator {
     static void generateManifestFileContent(Project project, ArrayList<String> excludeProcessNames) {
         def android = project.extensions.getByType(AppExtension)
         android.applicationVariants.all { variant ->
-            String pkgName = [variant.mergedFlavor.applicationId, variant.buildType.applicationIdSuffix].findAll().join()
+            String pkgName = [variant.mergedFlavor.applicationId, variant.mergedFlavor.applicationIdSuffix, variant.buildType.applicationIdSuffix].findAll().join()
             variant.outputs.each { output ->
                 output.processManifest.doLast {
                     output.processManifest.outputs.files.each { File file ->

--- a/cc-settings-2.gradle
+++ b/cc-settings-2.gradle
@@ -7,8 +7,7 @@
 //  支持新增自定义的其它自动注册功能，参考AutoRegister，用法参考cc-settings-demo.gradle
 project.apply plugin: 'cc-register'
 def dependencyMode = GradleVersion.version(project.gradle.gradleVersion) >= GradleVersion.version('4.1') ? 'api' : 'compile'
-//project.dependencies.add(dependencyMode, project(":cc"))
-project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.4") //用最新版
+project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.5") //用最新版
 
 //此文件是作为组件化配置的公共gradle脚本文件，在每个组件中都apply此文件，下载到工程根目录后，可以在下方添加一些自己工程中通用的配置
 // 可参考cc-settings-demo.gradle
@@ -19,12 +18,14 @@ project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.4") //用最�
 //      4. 其它公共配置信息
 
 //开启app内部多进程组件调用时启用下面这行代码
+//文档地址：https://luckybilly.github.io/CC-website/#/manual-multi-process
 //ccregister.multiProcessEnabled = true
 
 //开启app内部多进程组件调用时，可以启用下方的配置排除一些进程
 //ccregister.excludeProcessNames = [':pushservice', ':processNameB']
 
 //按照如下格式添加自定义注册项，可添加多个（也可每次add一个，add多次）
+// 文档地址： https://luckybilly.github.io/CC-website/#/manual-IActionProcessor
 //ccregister.registerInfo.add([
 //        //在自动注册组件的基础上增加：自动注册组件B的processor
 //        'scanInterface'             : 'com.billy.cc.demo.component.b.processor.IActionProcessor'

--- a/cc-settings-2.gradle
+++ b/cc-settings-2.gradle
@@ -8,7 +8,7 @@
 project.apply plugin: 'cc-register'
 def dependencyMode = GradleVersion.version(project.gradle.gradleVersion) >= GradleVersion.version('4.1') ? 'api' : 'compile'
 //project.dependencies.add(dependencyMode, project(":cc"))
-project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.3") //用最新版
+project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.4") //用最新版
 
 //此文件是作为组件化配置的公共gradle脚本文件，在每个组件中都apply此文件，下载到工程根目录后，可以在下方添加一些自己工程中通用的配置
 // 可参考cc-settings-demo.gradle

--- a/cc-settings-2.gradle
+++ b/cc-settings-2.gradle
@@ -8,7 +8,7 @@
 project.apply plugin: 'cc-register'
 def dependencyMode = GradleVersion.version(project.gradle.gradleVersion) >= GradleVersion.version('4.1') ? 'api' : 'compile'
 //project.dependencies.add(dependencyMode, project(":cc"))
-project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.2") //用最新版
+project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.3") //用最新版
 
 //此文件是作为组件化配置的公共gradle脚本文件，在每个组件中都apply此文件，下载到工程根目录后，可以在下方添加一些自己工程中通用的配置
 // 可参考cc-settings-demo.gradle

--- a/cc-settings-demo.gradle
+++ b/cc-settings-demo.gradle
@@ -7,7 +7,9 @@
 //
 //-----------------------------------------------------------
 
-apply from: rootProject.file('cc-settings-2.gradle')
+project.apply plugin: 'cc-register'
+def dependencyMode = GradleVersion.version(project.gradle.gradleVersion) >= GradleVersion.version('4.1') ? 'api' : 'compile'
+project.dependencies.add(dependencyMode, "com.billy.android:cc:2.1.5") //用最新版
 
 dependencies {
     implementation project(':demo_base')

--- a/cc/build.gradle
+++ b/cc/build.gradle
@@ -52,7 +52,7 @@ ext {
     siteUrl = 'https://github.com/luckybilly/CC'
     gitUrl = 'git@github.com:luckybilly/CC.git'
 
-    libraryVersion = '2.1.4'
+    libraryVersion = '2.1.5'
 
     developerId = 'billy'
     developerName = 'billy'

--- a/cc/build.gradle
+++ b/cc/build.gradle
@@ -52,7 +52,7 @@ ext {
     siteUrl = 'https://github.com/luckybilly/CC'
     gitUrl = 'git@github.com:luckybilly/CC.git'
 
-    libraryVersion = '2.1.3'
+    libraryVersion = '2.1.4'
 
     developerId = 'billy'
     developerName = 'billy'

--- a/cc/build.gradle
+++ b/cc/build.gradle
@@ -52,7 +52,7 @@ ext {
     siteUrl = 'https://github.com/luckybilly/CC'
     gitUrl = 'git@github.com:luckybilly/CC.git'
 
-    libraryVersion = '2.1.2'
+    libraryVersion = '2.1.3'
 
     developerId = 'billy'
     developerName = 'billy'

--- a/cc/src/main/java/com/billy/cc/core/component/SubProcessCCInterceptor.java
+++ b/cc/src/main/java/com/billy/cc/core/component/SubProcessCCInterceptor.java
@@ -129,6 +129,7 @@ class SubProcessCCInterceptor implements ICCInterceptor {
                     }
                 });
             } catch (DeadObjectException e) {
+                RemoteCCService.remove(processName);
                 connectionCache.remove(processName);
                 call(remoteCC);
             } catch (Exception e) {

--- a/cc/src/main/java/com/billy/cc/core/component/remote/RemoteParamUtil.java
+++ b/cc/src/main/java/com/billy/cc/core/component/remote/RemoteParamUtil.java
@@ -6,8 +6,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
-import android.util.Size;
-import android.util.SizeF;
 import android.util.SparseArray;
 
 import com.billy.cc.core.component.CC;
@@ -112,7 +110,7 @@ public class RemoteParamUtil {
                 || v instanceof Bundle
                 || v instanceof Parcelable              || v instanceof Parcelable[]
                 || v instanceof CharSequence[]          || v instanceof IBinder
-                || v instanceof Size                    || v instanceof SizeF ) {
+                ) {
             return v;
         } else if (v instanceof SparseArray) {
             SparseArray sa = (SparseArray) v;

--- a/demo_component_jsbridge/src/main/java/com/billy/cc/demo/component/jsbridge/JsBridgeComponent.java
+++ b/demo_component_jsbridge/src/main/java/com/billy/cc/demo/component/jsbridge/JsBridgeComponent.java
@@ -27,7 +27,7 @@ public class JsBridgeComponent implements IComponent {
                 // 在任意进程可以调用此action来创建一个新的面向组件封装的WebView
                 return createWebView(cc);
             default:
-                CC.sendCCResult(cc.getCallId(), CCResult.error("unsupported action name:" + actionName));
+                CC.sendCCResult(cc.getCallId(), CCResult.errorUnsupportedActionName());
                 break;
         }
         return false;
@@ -35,9 +35,7 @@ public class JsBridgeComponent implements IComponent {
 
     private boolean createWebView(CC cc) {
         BridgeWebView webView = BridgeWebViewHelper.createWebView(cc.getContext());
-        CCResult result = CCResult.success()
-                .addData("webView", webView);
-        CC.sendCCResult(cc.getCallId(), result);
+        CC.sendCCResult(cc.getCallId(), CCResult.success("webView", webView));
         return false;
     }
 }

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,8 @@
 
 # 更新日志
 
+[点击这里查看最新的更新日志](https://luckybilly.github.io/CC-website/#/changelog)
+
 - 2019.01.30 V2.1.2
 
 ~~~


### PR DESCRIPTION
CC升级到2.1.5: 修复在子进程被杀死的情况下调用该子进程中的组件时出现的crash

cc-register插件升级到1.0.9：新增class文件扫描缓存功能，来自[PR #115](https://github.com/luckybilly/CC/pull/115)，贡献者: [zhangkangbin](https://github.com/zhangkangbin)