### PR TITLE
debug模式下，android 10后台打开跨apk的activity的问题

### DIFF
--- a/cc-settings-demo.gradle
+++ b/cc-settings-demo.gradle
@@ -11,6 +11,24 @@ project.apply plugin: 'cc-register'
 //project.dependencies.add('api', project(':cc')) //用最新版
 project.dependencies.add('api', "com.billy.android:cc:2.1.6") //用最新版
 
+android {
+    signingConfigs {
+        releaseconfig {
+            storeFile rootProject.file('cc.keystore')
+            storePassword 'cc-demo'
+            keyAlias 'cc-demo'
+            keyPassword 'cc-demo'
+        }
+    }
+    buildTypes {
+
+        debug {
+            minifyEnabled false
+            debuggable true
+            signingConfig signingConfigs.releaseconfig
+        }
+    }
+}
 dependencies {
     //其它apply当前gradle文件的module统一添加对demo_base的依赖
     if (project.name != 'demo_base'){

--- a/demo/src/main/debug/AndroidManifest.xml
+++ b/demo/src/main/debug/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.billy.cc.demo"
+    android:sharedUserId="com.billy.cc">
+
+    <application android:name=".MyApp"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity android:name="com.billy.cc.demo.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:name=".lifecycle.LifecycleActivity" />
+
+    </application>
+
+</manifest>

--- a/demo_component_a/src/main/debug/AndroidManifest.xml
+++ b/demo_component_a/src/main/debug/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.billy.cc.demo.component.a" >
+    package="com.billy.cc.demo.component.a"
+    android:sharedUserId="com.billy.cc" >
 
     <application
         android:name="debug.MyApp"

--- a/demo_component_b/src/main/debug/AndroidManifest.xml
+++ b/demo_component_b/src/main/debug/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.billy.cc.demo.component.b" >
+    package="com.billy.cc.demo.component.b"
+    android:sharedUserId="com.billy.cc" >
 
     <application
         android:name="debug.MyApp"

--- a/demo_component_jsbridge/src/main/debug/AndroidManifest.xml
+++ b/demo_component_jsbridge/src/main/debug/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.billy.cc.demo.component.jsbridge">
+    package="com.billy.cc.demo.component.jsbridge"
+    android:sharedUserId="com.billy.cc">
 
     <application
         android:name="debug.jsbridge.MyApp"

--- a/demo_component_kt/src/main/debug/AndroidManifest.xml
+++ b/demo_component_kt/src/main/debug/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.billy.cc.demo.component.kt">
+    package="com.billy.cc.demo.component.kt"
+    android:sharedUserId="com.billy.cc">
 
     <application
         android:name="debug.kt.MyApp"


### PR DESCRIPTION
通过指定相同的sharedUserId、相同的签名来解决。

此方案是在应用层解决，只修改需要独立编译组件的debug目录下的`AndroidManifest.xml`，以及将debug模式需要指定的signingConfig配置在 公共的`cc-settings-demo.gradle`中。
优点是对relase包没有影响，缺点是集成复杂性提高了。